### PR TITLE
Changed requirement from psycopg2 to psycopg2-binary

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 python-dotenv==0.21.1
 pandas==1.4.1
 SQLAlchemy==1.4.22
-psycopg2==2.8.6
+psycopg2-binary==2.9.6
 pydash==5.1.0
 xmltodict==0.12.0
 schema==0.7.5


### PR DESCRIPTION
The package does not work on my Mac with a fresh conda 3.9 env unless I install psycopg2-binary. I changed the requirements.txt accordingly. I tested with another fresh 3.9 env and now all tests pass. 