### PR TITLE
Bump pip to 23.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,14 @@
-import os
 import setuptools
-from pip._internal.req import parse_requirements
-from pip._internal.network.session import PipSession
 
-this_dir = os.path.dirname(os.path.abspath(__file__))
-pip_requirements = parse_requirements(
-    os.path.join(this_dir, "requirements.txt"), PipSession())
-reqs = [pii.requirement for pii in pip_requirements]
+with open('requirements.txt') as f:
+    requirements = f.read().splitlines()
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setuptools.setup(
     name="battetl",
-    version="1.0.1",
+    version="1.0.2",
     author="Zander Nevitt, Bing Syuan Wang and Chintan Pathak",
     author_email="info@battgenie.life",
     description="A Python module for extracting, transforming, and loading battery data to a database.",
@@ -21,7 +16,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/BattGenie/battetl",
     packages=setuptools.find_packages(),
-    install_requires=reqs,
+    install_requires=requirements,
     classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
This PR updates the codebase to remove the usage of `import pip`. 
As of the release of `pip` 23.1 on 4/15
https://discuss.python.org/t/announcement-pip-23-1-release/25844
The official documentation recommends against using import pip. 
https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program

Also boost version to 1.0.2 to support pip 23.1 installation