### PR TITLE
Added BattDbTestHelper class to module

### DIFF
--- a/battetl/load/__init__.py
+++ b/battetl/load/__init__.py
@@ -1,1 +1,2 @@
 from .Loader import Loader
+from .batt_db_test_helper import BattDbTestHelper

--- a/battetl/load/batt_db_test_helper.py
+++ b/battetl/load/batt_db_test_helper.py
@@ -1,4 +1,3 @@
-import battetl.load
 import psycopg2.sql
 import pandas as pd
 import random
@@ -6,8 +5,10 @@ import string
 from psycopg2 import sql
 from copy import deepcopy
 
+from .Loader import Loader
 
-class LoaderTestHelper(battetl.load.Loader):
+
+class BattDbTestHelper(Loader):
 
     cell_type_id = None
     cell_id = None
@@ -18,7 +19,7 @@ class LoaderTestHelper(battetl.load.Loader):
 
     def __init__(self, config: dict):
         '''
-        Various methods for helping loader tests.
+        Various methods to help with tests involving BattDB
         '''
         super().__init__(config)
         self.config = config['meta_data']

--- a/tests/test_BattETL.py
+++ b/tests/test_BattETL.py
@@ -4,7 +4,7 @@ import pytest
 import pandas as pd
 
 from battetl import BattETL
-from loader_test_helper import LoaderTestHelper
+from battetl.load import BattDbTestHelper
 
 CONFIG_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
@@ -19,12 +19,12 @@ class Values:
         The BattETL object that is used in the tests
     CONFIG_1 : dict
         The configuration dictionary for the test
-    TEST_HELPER : LoaderTestHelper
-        The LoaderTestHelper object that is used in the tests
+    TEST_HELPER : BattDbTestHelper
+        The BattDbTestHelper object that is used in the tests
     """
     cell: BattETL = None
     CONFIG_1: dict = None
-    TEST_HELPER: LoaderTestHelper = None
+    TEST_HELPER: BattDbTestHelper = None
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -36,7 +36,7 @@ def add_database_test_entries():
     with open(os.path.join(CONFIG_DIR, 'config_1.json')) as config_file:
         Values.CONFIG_1 = json.load(config_file)
 
-    Values.TEST_HELPER = LoaderTestHelper(Values.CONFIG_1)
+    Values.TEST_HELPER = BattDbTestHelper(Values.CONFIG_1)
 
     # Will be executed before the first test
     Values.TEST_HELPER.create_test_db_entries()

--- a/tests/test_Loader.py
+++ b/tests/test_Loader.py
@@ -4,8 +4,7 @@ import pytest
 import pandas as pd
 from copy import deepcopy
 
-from battetl.load import Loader
-from loader_test_helper import LoaderTestHelper
+from battetl.load import Loader, BattDbTestHelper
 
 CONFIG_DIR = os.path.join(os.path.dirname(__file__), 'configs')
 
@@ -18,11 +17,11 @@ class Values:
     ----------
     CONFIG_1: dict
         The configuration dictionary for the test
-    TEST_HELPER: LoaderTestHelper
-        The LoaderTestHelper object that is used in the tests
+    TEST_HELPER: BattDbTestHelper
+        The BattDbTestHelper object that is used in the tests
     """
     CONFIG_1: dict = None
-    TEST_HELPER: LoaderTestHelper = None
+    TEST_HELPER: BattDbTestHelper = None
 
 
 @pytest.fixture(scope='module', autouse=True)
@@ -34,7 +33,7 @@ def add_database_test_entries():
     with open(os.path.join(CONFIG_DIR, 'config_1.json')) as config_file:
         Values.CONFIG_1 = json.load(config_file)
 
-    Values.TEST_HELPER = LoaderTestHelper(Values.CONFIG_1)
+    Values.TEST_HELPER = BattDbTestHelper(Values.CONFIG_1)
 
     # Will be executed before the first test
     Values.TEST_HELPER.create_test_db_entries()


### PR DESCRIPTION
Moved the helper class `LoaderTestHelper` from `tests/` directory into the BattETL module and renamed it to `BattDbTestHelper`. Now that class can be used in other modules where testing requires reading/writing to BattDB (e.g. SilStreamer) 