### PR TITLE
retry when load test data unexpected error

### DIFF
--- a/battetl/constants.py
+++ b/battetl/constants.py
@@ -1,9 +1,9 @@
 class Constants:
     DEFAULT_TIME_ZONE = 'America/Los_Angeles'
 
-    MAX_RETRIES = 10
-    RETRY_DELAY = 10
-    MAX_RETRY_DELAY = 60
+    DATABASE_MAX_RETRIES = 10
+    DATABASE_RETRY_DELAY = 10
+    DATABASE_MAX_RETRY_DELAY = 60
 
     MAKE_ARBIN = 'arbin'
     MAKE_MACCOR = 'maccor'

--- a/battetl/constants.py
+++ b/battetl/constants.py
@@ -1,6 +1,10 @@
 class Constants:
     DEFAULT_TIME_ZONE = 'America/Los_Angeles'
 
+    MAX_RETRIES = 10
+    RETRY_DELAY = 10
+    MAX_RETRY_DELAY = 60
+
     MAKE_ARBIN = 'arbin'
     MAKE_MACCOR = 'maccor'
     DATA_TYPE_TEST_DATA = 'test_data'

--- a/battetl/load/Loader.py
+++ b/battetl/load/Loader.py
@@ -827,8 +827,9 @@ class Loader:
 
         test_id = self.__lookup_test_id()
         if not test_id:
+            test_name = self.config['test_meta']['test_name']
             logger.info(
-                f'No test data exists for {test_id}, OK to upload all data.')
+                f'No test data exists for "{test_name}", OK to upload all data.')
             return None
 
         with self.conn.cursor() as cursor:

--- a/battetl/load/Loader.py
+++ b/battetl/load/Loader.py
@@ -176,11 +176,11 @@ class Loader:
                     df=df_copy, target_table='test_data')
         except Exception as e:
             logger.error('Error loading test data')
-            if retry_cnt < Constants.MAX_RETRIES:
+            if retry_cnt < Constants.DATABASE_MAX_RETRIES:
                 logger.info(
-                    f'Retrying load_test_data() {retry_cnt+1}/{Constants.MAX_RETRIES}')
-                retry_delay = min(Constants.RETRY_DELAY *
-                                  (retry_cnt+1), Constants.MAX_RETRY_DELAY)
+                    f'Retrying load_test_data() {retry_cnt+1}/{Constants.DATABASE_MAX_RETRIES}')
+                retry_delay = min(Constants.DATABASE_RETRY_DELAY *
+                                  (retry_cnt+1), Constants.DATABASE_MAX_RETRY_DELAY)
                 logger.info(f'Retry delay: {retry_delay} seconds')
                 time.sleep(retry_delay)
 

--- a/battetl/load/Loader.py
+++ b/battetl/load/Loader.py
@@ -2,6 +2,7 @@ from battetl import logger, Constants, Utils
 import os
 import copy
 import json
+import time
 import psycopg2
 import psycopg2.pool
 import psycopg2.sql
@@ -121,7 +122,7 @@ class Loader:
         assert (self.__validate_config(config))
         assert (self.__create_connection())
 
-    def load_test_data(self, df: pd.DataFrame) -> int:
+    def load_test_data(self, df: pd.DataFrame, retry_cnt: int = 0) -> int:
         """
         Loads test data to the target database. Only loads data past the
         latest `unixtime_s` field that already exists in the `test_data` table.
@@ -130,38 +131,64 @@ class Loader:
         ----------
         df : pd.DataFrame
             Data Frame containing test data to load to database.
+        retry_cnt : int, optional
+            The number of times to retry loading data to the database.
 
         Returns
         -------
         num_rows_loaded : int
             The number of rows inserted into the `data` table.
         """
+        logger.info('Loading test data to database')
 
         num_rows_loaded = 0
 
         df_copy = df.copy(deep=True)
 
-        latest_unixtime_s = self.__lookup_latest_unixtime()
-        if latest_unixtime_s:
-            df_copy = df_copy[df_copy['unixtime_s'] > latest_unixtime_s]
+        try:
+            if retry_cnt > 0:
+                logger.info(f'Retry count: {retry_cnt}')
+                # Re-create connection
+                self.__create_connection()
 
-        if df_copy.shape[0] > 0:
-            # Move fields to other_detail
-            df_copy = self.__create_other_detail(
-                df_copy, Constants.COLUMNS_TEST_DATA)
+            latest_unixtime_s = self.__lookup_latest_unixtime()
+            if latest_unixtime_s:
+                df_copy = df_copy[df_copy['unixtime_s'] > latest_unixtime_s]
 
-            for column in df_copy.columns:
-                if column not in Constants.COLUMNS_TEST_DATA:
-                    logger.debug(f'Dropping column {column} from DataFrame')
-                    df_copy = df_copy.drop([column], axis=1)
+            if df_copy.shape[0] > 0:
+                # Move fields to other_detail
+                df_copy = self.__create_other_detail(
+                    df_copy, Constants.COLUMNS_TEST_DATA)
 
-            test_id = self.__lookup_test_id()
-            if not test_id:
-                test_id = self.__insert_test_meta()
-            df_copy['test_id'] = np.ones(
-                df_copy.shape[0], dtype=np.uint16) * test_id
-            
-            num_rows_loaded = self.__load_dataframe(df=df_copy, target_table='test_data')
+                for column in df_copy.columns:
+                    if column not in Constants.COLUMNS_TEST_DATA:
+                        logger.debug(
+                            f'Dropping column {column} from DataFrame')
+                        df_copy = df_copy.drop([column], axis=1)
+
+                test_id = self.__lookup_test_id()
+                if not test_id:
+                    test_id = self.__insert_test_meta()
+                df_copy['test_id'] = np.ones(
+                    df_copy.shape[0], dtype=np.uint16) * test_id
+
+                num_rows_loaded += self.__load_dataframe(
+                    df=df_copy, target_table='test_data')
+        except Exception as e:
+            logger.error('Error loading test data')
+            if retry_cnt < Constants.MAX_RETRIES:
+                logger.info(
+                    f'Retrying load_test_data() {retry_cnt+1}/{Constants.MAX_RETRIES}')
+                retry_delay = min(Constants.RETRY_DELAY *
+                                  (retry_cnt+1), Constants.MAX_RETRY_DELAY)
+                logger.info(f'Retry delay: {retry_delay} seconds')
+                time.sleep(retry_delay)
+
+                num_rows_loaded += self.load_test_data(
+                    df=df_copy, retry_cnt=retry_cnt+1)
+            else:
+                logger.error(f'Exceeded max retries for load_test_data()')
+                raise e
 
         return num_rows_loaded
 
@@ -180,6 +207,7 @@ class Loader:
         num_rows_loaded : int
             The number of rows inserted into the `test_data` table.
         """
+        logger.info('Loading cycle stats to database')
 
         df_copy = df.copy(deep=True)
 
@@ -911,5 +939,7 @@ class Loader:
             logger.error(
                 f'Unexpected error inserting into {target_table} table.')
             logger.error(e)
+            if target_table == 'test_data':
+                raise e
 
         return num_rows_inserted

--- a/battetl/logger.py
+++ b/battetl/logger.py
@@ -11,6 +11,7 @@ from logging.handlers import RotatingFileHandler
 load_dotenv()
 
 LOG_MAX_SIZE = 10 * 1024 * 1024  # 10 MB
+STREAM_LOG_MAX_LENGTH = 1000
 MODULE_DIR = os.path.abspath(os.path.dirname(__file__))
 LOG_DIR = os.path.join(MODULE_DIR, "logs")
 if not os.path.isdir(LOG_DIR):
@@ -26,16 +27,16 @@ LOG_FILE_PATH = os.path.join(LOG_DIR, LOG_FILE_NAME)
 # module: The module (name portion of filename).
 # lineno: Source line number where the logging call was issued (if available).
 # message: The logged message.
-LOG_FORMAT = '%(asctime)s %(levelname)s [%(module)s:%(lineno)d] %(message)s'
-
 logger = logging.getLogger('battetl')
 
-formatter_stream = logging.Formatter(fmt=LOG_FORMAT)
+log_format_stream = f'%(asctime)s %(levelname)s [%(module)s:%(lineno)d] %(message).{STREAM_LOG_MAX_LENGTH}s'
+formatter_stream = logging.Formatter(fmt=log_format_stream)
 handler_stream = logging.StreamHandler()
 handler_stream.setFormatter(formatter_stream)
 logger.addHandler(handler_stream)
 
-formatter_file = logging.Formatter(fmt=LOG_FORMAT)
+log_format_file = '%(asctime)s %(levelname)s [%(module)s:%(lineno)d] %(message)s'
+formatter_file = logging.Formatter(fmt=log_format_file)
 handler_file = RotatingFileHandler(
     LOG_FILE_PATH, maxBytes=LOG_MAX_SIZE, backupCount=10, delay=True)
 handler_file.setFormatter(formatter_file)


### PR DESCRIPTION
When the amount of data is too large or the network connection is unstable, there may be unexpected errors. This PR adds a retry mechanism.

- Retry if load test data error. The retry attempts are set to a maximum of 10 times, with increasing wait times between attempts (10 seconds, 20 seconds, and up to 60 seconds).
- This retry will not re-copy the DataFrame which saves the processing time of `__create_other_detail`.
- To avoid displaying too many SQL commands in the error messages, this PR sets the limit of stream log size to 1000 characters. Displaying too many error logs can slow down IDEs, such as Notebook. However, there will be no such limit in the log file, which can be opened to view the complete error message.